### PR TITLE
Allow for custom senses, ignore PP

### DIFF
--- a/scripts/sbiParser.js
+++ b/scripts/sbiParser.js
@@ -652,9 +652,20 @@ export class sbiParser {
                 .split(",")
                 .map(line => line.trim());
 
-            const actorData = {};
+            const actorData = {
+                data: {
+                    attributes: {
+                        senses: {
+                            special: "",
+                        },
+                    },
+                },
+            };
 
             for (const sense of senses) {
+                           if (/^passive perception \d+$/.test(sense.toLowerCase())) {
+                continue; // Ignore Passive Perception
+            }
                 const match = this.#sensesRegex.exec(sense);
 
                 if (match) {
@@ -667,7 +678,11 @@ export class sbiParser {
                         sbiUtils.assignToObject(actorData, "token.dimSight", modifier);
                     }
                 } else {
-                    sbiUtils.assignToObject(actorData, "data.attributes.senses.special", sbiUtils.capitalizeAll(sense));
+                     if (actorData.data.attributes.senses.special) {
+                           actorData.data.attributes.senses.special += "; ";
+                     }
+                     actorData.data.attributes.senses.special += sbiUtils.capitalizeAll(sense);
+
                 }
             }
 


### PR DESCRIPTION
Handle multiple custom Senses, split with a semicolon per `https://github.com/foundryvtt/dnd5e/issues/968` and ignore Passive Perception since the system calculates that on its own